### PR TITLE
fix: update Pathfinder font to only apply to the icon characters

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -5,6 +5,7 @@
     font-weight: normal;
     font-style: normal;
     font-display: block;
+	unicode-range: U+2B32, U+2B3A, U+2B3B, U+2B3D, U+2B53;
 }
 
 .pf2-actions {


### PR DESCRIPTION
Update Pathfinder font to only apply to the icon characters. This fixes javalent/fantasy-statblocks#449, which appeared because fantasy-statblocks now prioritizes the Pathfinder font above all others (which fixed the action icons not showing properly on iOS).